### PR TITLE
add healthcheck and configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,20 @@ on:
   pull_request:
 
 jobs:
+
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 18 }
+      - run: npm ci
+      - run: npx cypress verify
+      - name: UI healthcheck
+        run: npm run check:ui
+
   cypress-run:
+    needs: sanity
     runs-on: ubuntu-latest
 
     steps:
@@ -22,5 +35,5 @@ jobs:
       - name: Instalar dependências
         run: npm install
 
-      - name: Rodar Cypress (modo headless)
-        run: npx cypress run
+      - name: Rodar Cypress 
+        run: npm run cy:run

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "cypress";
-import fs from "node:fs";
-import path from "node:path";
+import * as fs from "fs";
+import * as path from "path";
 
 /**
  * Carrega variáveis de ambiente locais de cypress/config/env.local.json (se existir).

--- a/cypress/e2e/common/healthcheck.cy.ts
+++ b/cypress/e2e/common/healthcheck.cy.ts
@@ -1,0 +1,6 @@
+describe('healthcheck', () => {
+  it('abre a home do front', () => {
+    cy.visit('https://front.serverest.dev');
+    cy.contains('ServeRest').should('be.visible');
+  });
+});

--- a/cypress/e2e/common/healthcheck.cy.ts
+++ b/cypress/e2e/common/healthcheck.cy.ts
@@ -1,6 +1,5 @@
 // cypress/e2e/common/healthcheck.cy.ts
 describe('healthcheck (login)', () => {
-  // aumenta timeouts só pra este spec
   before(() => {
     Cypress.config('pageLoadTimeout', 60000);
     Cypress.config('defaultCommandTimeout', 10000);
@@ -19,10 +18,10 @@ describe('healthcheck (login)', () => {
     // container principal
     cy.get('.login-page.container', { timeout: 20000 }).should('be.visible');
 
-    // título "Login"
+    // título Login
     cy.contains('h1.font-robot', 'Login', { timeout: 20000 }).should('be.visible');
 
-    // campos de email/senha (placeholders conforme a UI)
+    // campos de email/senha 
     cy.get('input[placeholder="Digite seu email"]').should('be.visible');
     cy.get('input[placeholder="Digite sua senha"]').should('be.visible');
 

--- a/cypress/e2e/common/healthcheck.cy.ts
+++ b/cypress/e2e/common/healthcheck.cy.ts
@@ -1,6 +1,35 @@
-describe('healthcheck', () => {
-  it('abre a home do front', () => {
-    cy.visit('https://front.serverest.dev');
-    cy.contains('ServeRest').should('be.visible');
+// cypress/e2e/common/healthcheck.cy.ts
+describe('healthcheck (login)', () => {
+  // aumenta timeouts só pra este spec
+  before(() => {
+    Cypress.config('pageLoadTimeout', 60000);
+    Cypress.config('defaultCommandTimeout', 10000);
+  });
+
+  it('deve responder 200 no /login (sem render)', () => {
+    cy.request({
+      url: `${Cypress.config('baseUrl')}/login`,
+      failOnStatusCode: false
+    }).its('status').should('be.oneOf', [200, 304]);
+  });
+
+  it('deve renderizar a página de login e elementos principais', { retries: 2 }, () => {
+    cy.visit('/login', { failOnStatusCode: false });
+
+    // container principal
+    cy.get('.login-page.container', { timeout: 20000 }).should('be.visible');
+
+    // título "Login"
+    cy.contains('h1.font-robot', 'Login', { timeout: 20000 }).should('be.visible');
+
+    // campos de email/senha (placeholders conforme a UI)
+    cy.get('input[placeholder="Digite seu email"]').should('be.visible');
+    cy.get('input[placeholder="Digite sua senha"]').should('be.visible');
+
+    // botão Entrar com data-testid estável
+    cy.get('[data-testid="entrar"]')
+      .should('be.visible')
+      .and('contain', 'Entrar')
+      .and('not.be.disabled');
   });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+/// <reference types="cypress" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.11.0",
+        "@types/node": "^20.12.12",
         "cypress": "^13.9.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.5"
       },
       "engines": {
         "node": ">=18"
@@ -80,13 +80,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
-      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
-      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
         {
@@ -595,14 +595,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
+      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.6",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -613,7 +613,6 @@
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
-        "ci-info": "^4.0.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
         "commander": "^6.2.1",
@@ -628,6 +627,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -641,8 +641,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
-        "tree-kill": "1.2.2",
+        "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -1205,6 +1204,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2038,16 +2050,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2089,9 +2091,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2103,9 +2105,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "cy:run": "cypress run",
     "cy:api": "cypress run --spec 'cypress/e2e/api/**/*.cy.ts'",
     "cy:ui": "cypress run --spec 'cypress/e2e/ui/**/*.cy.ts'",
+    "check:ui": "cypress run --spec cypress/e2e/common/healthcheck.cy.ts",
+
 
     "typecheck": "tsc -p tsconfig.json",
     "lint": "npm run typecheck",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "cy:run": "cypress run",
     "cy:api": "cypress run --spec 'cypress/e2e/api/**/*.cy.ts'",
     "cy:ui": "cypress run --spec 'cypress/e2e/ui/**/*.cy.ts'",
-    "test": "cypress run",
-    "lint": "tsc --noEmit",
-    "pretest": "tsc --noEmit"
+
+    "typecheck": "tsc -p tsconfig.json",
+    "lint": "npm run typecheck",
+    "pretest": "npm run typecheck",
+    "test": "cypress run"
   },
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^20.12.12",
     "cypress": "^13.9.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["cypress", "node"],
@@ -18,10 +19,6 @@
       "@constants/*": ["src/constants/*"]
     }
   },
-  "include": [
-    "cypress/**/*.ts",
-    "src/**/*.ts",
-    "cypress.config.ts"
-  ],
+  "include": ["cypress/**/*.ts", "src/**/*.ts", "cypress.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# configurar TS/Cypress; test(ui): adicionar healthcheck; chore(npm): add script `check:ui`

## Contexto
A estrutura do projeto já está na `main`.  
Este PR:
- configura o **TypeScript** para funcionar com **Cypress** e **Node**;
- adiciona um **teste mínimo de saúde (healthcheck)** da página de login;
- inclui um **script npm** para rodar apenas o healthcheck de forma rápida.

## Alterações
- **TypeScript / Cypress**
  - `tsconfig.json`: `types: ["cypress","node"]`, `include` cobrindo `cypress/**`, `src/**` e `cypress.config.ts`; remoção de `typeRoots`.
  - `cypress.config.ts`: imports ajustados para módulos nativos (`fs`, `path`).
- **Teste de sanity**
  - `cypress/e2e/common/healthcheck.cy.ts`: valida `/login` (status 200/304) e renderização dos elementos-chave.
  - `cypress/support/e2e.ts`: referência de tipos global do Cypress.
- **Scripts**
  - `package.json`: adicionado `check:ui` (`cypress run --spec cypress/e2e/common/healthcheck.cy.ts`).

## Como testar
```bash
npm install
npx cypress verify
npm run typecheck
npm run check:ui      # executa apenas o healthcheck
# ou
npm run cy:run        # executa toda a suíte