### PR TITLE
produtos E2E + negativos; service/geradores; ajuste prefer-const

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Automação de testes para a aplicação [ServeRest](https://serverest.dev), des
 
 Este projeto cobre **testes de API** e **testes de Frontend (UI)** utilizando o **Cypress** com **TypeScript**, seguindo boas práticas de arquitetura, organização e manutenção.
 
----
 
 ## ✅ Pré-requisitos
 
@@ -12,7 +11,6 @@ Este projeto cobre **testes de API** e **testes de Frontend (UI)** utilizando o 
 - **Git**
 - (Opcional) **VS Code** + extensão oficial do Cypress
 
----
 
 ## 📂 Estrutura de Pastas
 
@@ -40,17 +38,17 @@ serverest-qa-senior/
 ├── cypress.config.ts                # Configuração principal do Cypress
 ├── package.json                     # Dependências e scripts do projeto
 ├── README.md                        # Documentação do projeto
-└── tsconfig.json                    # Configuração do TypeScript
+├── tsconfig.json                    # Configuração do TypeScript
+├──eslint.config.cjs                 # ESLint v9 (flat) + unused-imports
+└──scripts/check-exports.cjs         # ts-prune wrapper (CI-friendly)
 
 ```
----
 
 ## 🚀 Tecnologias Utilizadas
 - [Cypress](https://www.cypress.io/) para automação de testes
 - [TypeScript](https://www.typescriptlang.org/) para tipagem estática
 - [GitHub Actions](https://github.com/features/actions) para integração contínua (CI/CD)
 
----
 
 ## 📌 Objetivo
 O objetivo deste repositório é entregar uma automação completa para a aplicação **ServeRest**, cobrindo:
@@ -58,7 +56,6 @@ O objetivo deste repositório é entregar uma automação completa para a aplica
 2. **Testes de UI** — Fluxo de login e compra de produto.
 3. **Boas práticas de QA Sênior** — Arquitetura limpa, reuso de código, e execução em CI.
 
----
 
 ## 🔧 Setup do Projeto
 
@@ -76,7 +73,6 @@ npx cypress verify
 # 4) Checar tipagem TypeScript
 npm run typecheck
 ```
----
 
 ## 🧪 Testes e Scripts
 
@@ -108,7 +104,6 @@ Spec: `cypress/e2e/common/healthcheck.cy.ts`
 - Verifica resposta **200/304** do `/login`
 - Valida renderização de elementos-chave (título, inputs, botão `data-testid="entrar"`), com timeouts e retries seguros
 
----
 
 ## 🧪 Padrões de Teste
 
@@ -116,9 +111,7 @@ Spec: `cypress/e2e/common/healthcheck.cy.ts`
 - Validar **status** e **shape**; mensagens de erro via `expectErrorContains`.
 - Após **DELETE**, **reconsultar** o recurso para garantir remoção efetiva.
 
----
 ## ⚙️ Detalhes de Configuração
-
 
 - **TypeScript (`tsconfig.json`)**
   - Resolução de paths (`@helpers/*`, `@services/*`, `@types/*`, `@constants/*`).
@@ -132,17 +125,13 @@ Spec: `cypress/e2e/common/healthcheck.cy.ts`
   - `env.apiUrl`: `https://serverest.dev`
   - Suporte a `cypress/config/env.local.json` (git-ignored) para sobrescrever valores locais.
 
----
 
 ## 🤖 CI (GitHub Actions)
 Pipeline simples em `.github/workflows/ci.yml` executando Cypress em `ubuntu-latest`.  
 (opcional) Você pode adicionar um job de **sanity** chamando `npm run check:ui` antes da suíte completa.
-
----
 
 ## 🩺 Troubleshooting
 - **Types do Cypress/Node não encontrados**:  
   `npm install`, selecione **TypeScript: Use Workspace Version** no VS Code e rode `npm run typecheck`.
 - **Timeout para carregar a UI**:  
   Use `npm run check:ui` (spec com timeouts/retries específicos) ou ajuste `pageLoadTimeout`/`defaultCommandTimeout` conforme necessário.
----

--- a/cypress/e2e/api/products.cy.ts
+++ b/cypress/e2e/api/products.cy.ts
@@ -1,0 +1,143 @@
+import * as Users from '@services/userService'
+import * as Auth from '@services/authService'
+import * as Products from '@services/productService'
+import type { AdminCtx } from '../../../src/types/auth';
+
+import { makeRandomUser, makeRandomProduct } from '@helpers/generateData';
+import { randomAlphaNumId } from '@helpers/id';
+import { expectErrorContains } from '@helpers/assertions';
+
+describe('API - Produtos (E2E + cenários de falha)', () => {
+  const admin: AdminCtx = { email: '', password: '', id: '', token: '' };
+  const createdProductIds: string[] = [];
+  const createdUserIds: string[] = [];
+
+  before(() => {
+    const u = makeRandomUser(true);
+    admin.email = u.email;
+    admin.password = u.password;
+
+    return Users.create(u)
+      .then((r) => {
+        expect(r.status).to.eq(201);
+        admin.id = r.body._id;
+        createdUserIds.push(admin.id);
+        return Auth.login(admin.email, admin.password);
+      })
+      .then((r) => {
+        expect(r.status).to.eq(200);
+        admin.token = r.body.authorization;
+      });
+  });
+
+  afterEach(() => {
+    const delAll = createdProductIds.map((pid) => Products.remove(pid, admin.token));
+    createdProductIds.length = 0;
+    return Cypress.Promise.all(delAll);
+  });
+
+  after(() => {
+    if (admin.id) {
+      return Users.remove(admin.id);
+    }
+  });
+
+  it('E2E: criar → buscar → editar → excluir (e validar 400 após exclusão)', () => {
+    const p = makeRandomProduct();
+    let id = '';
+
+    Products.create(p, admin.token)
+      .then((rCreate) => {
+        expect(rCreate.status).to.eq(201);
+        id = rCreate.body._id;
+        createdProductIds.push(id);
+
+        return Products.getById(id);
+      })
+      .then((rGet) => {
+        expect(rGet.status).to.eq(200);
+        expect(rGet.body).to.include({
+          nome: p.nome,
+          preco: p.preco,
+          descricao: p.descricao,
+          quantidade: p.quantidade,
+        });
+
+        const updated = { ...p, descricao: `${p.descricao} (editado)` };
+        return Products.update(id, updated, admin.token);
+      })
+      .then((rPut) => {
+        expect([200, 201]).to.include(rPut.status);
+
+        return Products.remove(id, admin.token);
+      })
+      .then((rDel) => {
+        expect(rDel.status).to.eq(200);
+        return Products.getById(id);
+      })
+      .then((rAfter) => {
+        expect(rAfter.status).to.eq(400);
+        expectErrorContains(rAfter.body, ['produto', 'nao encontrado']);
+      });
+  });
+
+  it('negativo: nome duplicado (400)', () => {
+    const p = makeRandomProduct();
+
+    Products.create(p, admin.token)
+      .then((r1) => {
+        expect(r1.status).to.eq(201);
+        createdProductIds.push(r1.body._id);
+
+        return Products.create(p, admin.token);
+      })
+      .then((r2) => {
+        expect(r2.status).to.eq(400);
+        expectErrorContains(r2.body, ['ja', 'existe', 'produto', 'nome']);
+      });
+  });
+
+  it('negativo: criar sem token (401)', () => {
+    const p = makeRandomProduct();
+    Products.create(p)
+      .then((r) => {
+        expect(r.status).to.eq(401);
+        expectErrorContains(r.body, ['token', 'ausente']);
+      });
+  });
+
+  it('negativo: criar com token de usuário NÃO administrador (403)', () => {
+    const u = makeRandomUser(false);
+    let userId = '';
+    let token = '';
+
+    Users.create(u)
+      .then((rUser) => {
+        expect(rUser.status).to.eq(201);
+        userId = rUser.body._id;
+        createdUserIds.push(userId);
+        return Auth.login(u.email, u.password);
+      })
+      .then((rLogin) => {
+        expect(rLogin.status).to.eq(200);
+        token = rLogin.body.authorization;
+
+        const p = makeRandomProduct();
+        return Products.create(p, token);
+      })
+      .then((r) => {
+        expect(r.status).to.eq(403);
+        expectErrorContains(r.body, ['rota', 'exclusiva', 'administradores']);
+      });
+  });
+
+  it('buscar por id VÁLIDO porém INEXISTENTE deve retornar 400 (não encontrado)', () => {
+    const fakeId = randomAlphaNumId(16);
+
+    Products.getById(fakeId)
+      .then((r) => {
+        expect(r.status).to.eq(400);
+        expectErrorContains(r.body, ['produto', 'nao encontrado']);
+      });
+  });
+});

--- a/src/helpers/generateData.ts
+++ b/src/helpers/generateData.ts
@@ -1,6 +1,6 @@
-// src/helpers/generateData.ts
 import type { User, AdminFlag } from '../types/user';
 import type { Product } from '../types/products';
+import { faker } from '@faker-js/faker';
 
 export function makeRandomUser(admin = false): User {
   const r = Math.floor(Math.random() * 1e9);
@@ -13,13 +13,11 @@ export function makeRandomUser(admin = false): User {
   };
 }
 
-export function makeRandomProduct(overrides: Partial<Product> = {}): Product {
-  const r = Math.floor(Math.random() * 1e9);
+export function makeRandomProduct(): Product {
   return {
-    nome: `Produto QA ${r}`,
-    preco: 199,
-    descricao: 'Produto de teste QA',
-    quantidade: 10,
-    ...overrides,
+    nome: `QA ${faker.commerce.productName()} ${faker.string.alphanumeric(6)}`,
+    preco: faker.number.int({ min: 10, max: 8000 }),
+    descricao: faker.commerce.product(),
+    quantidade: faker.number.int({ min: 1, max: 100 }),
   };
 }

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,0 +1,25 @@
+import { apiRequest } from './https';
+import type { Product } from '../types/products';
+
+const auth = (token?: string) => (token ? { Authorization: token } : undefined);
+
+export function create(produto: Product, token?: string) {
+  return apiRequest<{ _id: string }>('POST', '/produtos', produto, auth(token));
+}
+
+export function getById(id: string) {
+  return apiRequest<Product>('GET', `/produtos/${id}`);
+}
+
+export function update(id: string, produto: Product, token?: string) {
+  return apiRequest<{ message: string; _id?: string }>(
+    'PUT',
+    `/produtos/${id}`,
+    produto,
+    auth(token)
+  );
+}
+
+export function remove(id: string, token?: string) {
+  return apiRequest<{ message: string }>('DELETE', `/produtos/${id}`, undefined, auth(token));
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,6 @@
+export type AdminCtx = {
+  email: string;
+  password: string;
+  id: string;
+  token: string;
+};


### PR DESCRIPTION
# API Produtos (E2E + negativos) + Services/Helpers + Ajustes de Qualidade

## Objetivo
Expandir a cobertura da API adicionando **Produtos** no mesmo padrão sênior aplicado a **Usuários**, com arquitetura reutilizável, cenários E2E e negativos, e pequenos ajustes de qualidade.

---

## Principais mudanças

### Domínio/Tipos
- `src/types/products.ts`
  - Define apenas o tipo de domínio `Product` (padrão alinhado ao `User`).
- `src/types/auth.ts`
  - Adicionado `AdminCtx` (contexto de autenticação usado nos testes).

### Services
- `src/services/productService.ts`
  - `create`, `getById`, `update`, `remove` usando `apiRequest` (mesmo padrão do `userService`).
  - Tipagem inline dos retornos (ex.: `{ _id: string }`, `{ message: string }`). **Sem** criar interfaces extras de response.
- **Não houve alteração** em `src/services/https.ts` (mantido o contrato genérico `apiRequest<TRes, TReq>`).

### Helpers
- `src/helpers/generateData.ts`
  - `makeRandomProduct()` para gerar massa de produto única/estável (usa `@faker-js/faker`).

### Testes – Produtos
- `cypress/e2e/api/products.cy.ts` (padrão encadeado com `.then(...)`):
  - **E2E**: *criar → buscar → editar → excluir* + **verificação pós-exclusão** (GET retorna 400 “produto não encontrado”).
  - **Negativos**:
    - **nome duplicado** → 400 (“já existe produto com esse nome”);
    - **sem token** → 401 (“token ausente, inválido…”);
    - **token de usuário NÃO admin** → 403 (“rota exclusiva para administradores”);
    - **id válido porém inexistente** → 400 (“produto não encontrado”).
  - Uso de `expectErrorContains` para mensagens (normalização sem acentos).
  - Correção de lint `prefer-const` para o contexto `admin`.

> Observação: criação de **admin seed** no próprio teste (via `Users.create` + `Auth.login`) e limpeza de produtos no `afterEach`.

---

## Como testar

1) Instalar deps (se necessário)
```bash
npm ci
```

2) Checagens de qualidade
```bash
npm run lint:all   # typecheck + eslint (unused-imports) + ts-prune
```

3) Executar apenas a suíte de Produtos (headless)
```bash
npx cypress run --spec 'cypress/e2e/api/products.cy.ts'
```
ou no modo interativo:
```bash
npm run cy:open -- --e2e --config 'specPattern=cypress/e2e/api/products.cy.ts'
```

**Resultados esperados**
- Cenários E2E e negativos de produtos **passando**.
- Sem falhas de `lint:all`.

---

## Impacto/Risco
- **Baixo**. Mudanças isoladas a Produtos, com services/arquivos novos e testes cobrindo os fluxos principais.
- `https.ts` **inalterado** (sem risco colateral nas demais suítes).

---
